### PR TITLE
PRP-11: Expanded API endpoints

### DIFF
--- a/processes/api/app.py
+++ b/processes/api/app.py
@@ -7,13 +7,16 @@ from pathlib import Path
 from typing import Any, cast
 
 import pandas as pd
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Response
 
 from processes.api.models import (
     BundleManifest,
     OrchestratorRunRequest,
     OrchestratorRunResponse,
+    RunRegistryRow,
+    RunsListResponse,
 )
+from processes.dk_export import writer as dk_writer
 from processes.orchestrator import adapter as orch
 
 app = FastAPI()
@@ -99,3 +102,114 @@ def get_metrics(run_id: str) -> list[dict[str, Any]]:
         raise HTTPException(status_code=404, detail="metrics not found")
     df = pd.read_parquet(path)
     return cast(list[dict[str, Any]], df.to_dict(orient="records"))
+
+
+@app.get("/runs", response_model=RunsListResponse)  # type: ignore[misc]
+def list_runs(registry_path: str | None = None) -> RunsListResponse:
+    """List runs discovered in the registry parquet.
+
+    If the registry does not exist, returns an empty list.
+    """
+    reg_path = Path(registry_path or Path("data") / "registry" / "runs.parquet")
+    if not reg_path.exists():
+        return RunsListResponse(runs=[])
+    try:
+        df = pd.read_parquet(reg_path)
+    except Exception as e:  # pragma: no cover
+        raise HTTPException(
+            status_code=500,
+            detail=f"failed to read registry: {e}",
+        ) from e
+    rows = cast(list[dict[str, Any]], df.to_dict(orient="records"))
+    models = [RunRegistryRow.model_validate(r) for r in rows]
+    return RunsListResponse(runs=models)
+
+
+def _find_manifest_for_run(run_id: str, runs_root: Path) -> tuple[str, Path]:
+    """Return (run_type, manifest_path) for the first matching run dir.
+
+    Searches known run types under `runs_root`.
+    """
+    for rt in ("sim", "variants", "field", "optimizer", "ingest", "metrics"):
+        m = runs_root / rt / run_id / "manifest.json"
+        if m.exists():
+            return rt, m
+    raise FileNotFoundError("manifest not found for run_id")
+
+
+@app.get("/export/dk/{run_id}")  # type: ignore[misc]
+def export_dk_csv(
+    run_id: str,
+    runs_root: str | None = None,
+    top_n: int = 20,
+    dedupe: bool = True,
+) -> Response:
+    """Generate a DK-uploadable CSV from a run (sim or variants).
+
+    - For sim runs: ranks entrants by EV (mean prize) from sim_results.
+    - For variants runs: uses variant_catalog order (first N) as a simple heuristic.
+    """
+    root = Path(runs_root or "runs")
+    try:
+        run_type, manifest_path = _find_manifest_for_run(run_id, root)
+    except FileNotFoundError as e:
+        raise HTTPException(status_code=404, detail="run manifest not found") from e
+
+    if run_type == "sim":
+        sim_path, field_path = dk_writer.discover_from_sim_run(run_id, root)
+        sim_df = pd.read_parquet(sim_path)
+        field_df = pd.read_parquet(field_path)
+        export_df = dk_writer.build_export_df(
+            sim_df, field_df, top_n=int(top_n), dedupe=bool(dedupe)
+        )
+    elif run_type == "variants":
+        # Discover variant_catalog and derive export rows from export_csv_row
+        data = json.loads(manifest_path.read_text(encoding="utf-8"))
+        catalog_path: Path | None = None
+        for obj in data.get("outputs", []):
+            if obj.get("kind") == "variant_catalog":
+                catalog_path = Path(str(obj["path"]))
+                break
+        if catalog_path is None or not catalog_path.exists():
+            raise HTTPException(status_code=404, detail="variant catalog not found")
+        cat_df = pd.read_parquet(catalog_path)
+        # Build DataFrame with DK columns from export_csv_row
+        rows: list[dict[str, Any]] = []
+        for _, row in cat_df.head(int(top_n)).iterrows():
+            tokens = dk_writer._parse_export_row(
+                str(row.get("export_csv_row", ""))
+            )
+            players = [tokens.get(slot, "") for slot in dk_writer.DK_SLOTS_ORDER]
+            if "" in players:
+                raise HTTPException(
+                    status_code=400,
+                    detail="invalid export_csv_row in catalog",
+                )
+            rows.append(dict(zip(dk_writer.DK_SLOTS_ORDER, players, strict=True)))
+        export_df = pd.DataFrame(rows)
+    else:
+        raise HTTPException(status_code=400, detail=f"unsupported run_type: {run_type}")
+
+    # Serialize CSV with DK header order only
+    csv_text = export_df.to_csv(columns=dk_writer.DK_SLOTS_ORDER, index=False)
+    return Response(content=csv_text, media_type="text/csv")
+
+
+@app.get("/logs/{run_id}")  # type: ignore[misc]
+def get_logs(run_id: str, runs_root: str | None = None) -> dict[str, Any]:
+    """Return placeholder logs/debug info for a run.
+
+    If a `logs.txt` exists under the run dir, return its content; otherwise a stub.
+    """
+    root = Path(runs_root or "runs")
+    try:
+        run_type, manifest_path = _find_manifest_for_run(run_id, root)
+    except FileNotFoundError as e:
+        raise HTTPException(status_code=404, detail="run manifest not found") from e
+    run_dir = manifest_path.parent
+    logs_path = run_dir / "logs.txt"
+    if logs_path.exists():
+        content = logs_path.read_text(encoding="utf-8")
+        return {"run_id": run_id, "run_type": run_type, "logs": content}
+    # fallback placeholder
+    return {"run_id": run_id, "run_type": run_type, "message": "logs not available"}

--- a/processes/api/models.py
+++ b/processes/api/models.py
@@ -97,3 +97,18 @@ class BundleManifest(BaseModel):
     slate_id: str
     created_ts: str
     stages: list[BundleStage]
+
+
+class RunRegistryRow(BaseModel):
+    run_id: str
+    run_type: str
+    slate_id: str
+    status: str
+    primary_outputs: list[str] | None = None
+    metrics_path: str | None = None
+    created_ts: str
+    tags: list[str] | None = None
+
+
+class RunsListResponse(BaseModel):
+    runs: list[RunRegistryRow]

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+from httpx import AsyncClient
+
+from processes.api import app as api_app
+
+
+@pytest.mark.anyio
+async def test_list_runs_registry(tmp_path: Path) -> None:
+    # Build a small registry parquet
+    reg_dir = tmp_path / "data" / "registry"
+    reg_dir.mkdir(parents=True, exist_ok=True)
+    reg_path = reg_dir / "runs.parquet"
+    df = pd.DataFrame(
+        [
+            {
+                "run_id": "20250101_120000_deadbeef",
+                "run_type": "sim",
+                "slate_id": "20250101_NBA",
+                "status": "success",
+                "primary_outputs": ["/path/to/sim_results.parquet"],
+                "metrics_path": "/path/to/metrics.parquet",
+                "created_ts": "2025-01-01T12:00:00.000Z",
+                "tags": ["test"],
+            }
+        ]
+    )
+    df.to_parquet(reg_path)
+
+    async with AsyncClient(app=api_app, base_url="http://test") as ac:
+        resp = await ac.get("/runs", params={"registry_path": str(reg_path)})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "runs" in data and isinstance(data["runs"], list)
+        assert data["runs"][0]["run_id"] == "20250101_120000_deadbeef"
+
+
+@pytest.mark.anyio
+async def test_export_dk_csv_from_sim_run(tmp_path: Path) -> None:
+    # Create a sim run manifest and parquet artifacts
+    runs_root = tmp_path / "runs"
+    run_id = "RID123"
+    run_dir = runs_root / "sim" / run_id
+    artifacts = run_dir / "artifacts"
+    artifacts.mkdir(parents=True, exist_ok=True)
+
+    # Field with export_csv_row
+    def _row(players: list[str]) -> str:
+        slots = ["PG", "SG", "SF", "PF", "C", "G", "F", "UTIL"]
+        return ",".join(f"{s} {p}" for s, p in zip(slots, players, strict=True))
+
+    field_rows = [
+        {"entrant_id": 1, "export_csv_row": _row([f"p{i}" for i in range(1, 9)])},
+        {"entrant_id": 2, "export_csv_row": _row([f"q{i}" for i in range(1, 9)])},
+    ]
+    field_df = pd.DataFrame(field_rows)
+    field_path = artifacts / "field.parquet"
+    field_df.to_parquet(field_path)
+
+    # Sim results with two entrants and EV favoring entrant 1
+    sim_rows = [
+        {"world_id": 1, "entrant_id": 1, "prize": 100.0},
+        {"world_id": 1, "entrant_id": 2, "prize": 10.0},
+    ]
+    sim_df = pd.DataFrame(sim_rows)
+    sim_path = artifacts / "sim_results.parquet"
+    sim_df.to_parquet(sim_path)
+
+    manifest = {
+        "schema_version": "0.2.0",
+        "run_id": run_id,
+        "run_type": "sim",
+        "slate_id": "20250101_NBA",
+        "created_ts": "2025-01-01T12:00:00.000Z",
+        "inputs": [
+            {
+                "path": str(field_path),
+                "content_sha256": "x" * 64,
+                "role": "field",
+            }
+        ],
+        "outputs": [
+            {"path": str(sim_path), "kind": "sim_results"},
+            {"path": str(field_path), "kind": "field"},
+        ],
+    }
+    (run_dir / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+    async with AsyncClient(app=api_app, base_url="http://test") as ac:
+        resp = await ac.get(
+            f"/export/dk/{run_id}", params={"runs_root": str(runs_root), "top_n": 2}
+        )
+        assert resp.status_code == 200
+        assert resp.headers.get("content-type", "").startswith("text/csv")
+        csv_text = resp.text.strip().splitlines()
+        # header + 2 rows
+        assert len(csv_text) == 1 + 2
+        assert csv_text[0].startswith("PG,SG,SF,PF,C,G,F,UTIL")
+
+
+@pytest.mark.anyio
+async def test_logs_placeholder(tmp_path: Path) -> None:
+    runs_root = tmp_path / "runs"
+    run_id = "RIDLOG"
+    run_dir = runs_root / "sim" / run_id
+    (run_dir / "artifacts").mkdir(parents=True, exist_ok=True)
+    # minimal manifest
+    manifest = {
+        "schema_version": "0.2.0",
+        "run_id": run_id,
+        "run_type": "sim",
+        "slate_id": "20250101_NBA",
+        "created_ts": "2025-01-01T12:00:00.000Z",
+        "inputs": [],
+        "outputs": [],
+    }
+    (run_dir / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+    # write a logs.txt
+    (run_dir / "logs.txt").write_text("hello log", encoding="utf-8")
+
+    async with AsyncClient(app=api_app, base_url="http://test") as ac:
+        resp = await ac.get(f"/logs/{run_id}", params={"runs_root": str(runs_root)})
+        assert resp.status_code == 200
+        payload = resp.json()
+        assert payload["run_id"] == run_id
+        assert "hello log" in payload.get("logs", "")


### PR DESCRIPTION
## Scope
- Add endpoints: GET /runs, GET /export/dk/{run_id}, GET /logs/{run_id}
- Keep existing: GET /runs/{run_id}, GET /metrics/{run_id}
- Files: processes/api/app.py, processes/api/models.py, tests/test_api_endpoints.py

## Data contracts changed?
- No schema changes. Reused existing Pydantic models; added RunRegistryRow and RunsListResponse for registry listing.

## Seeds honored / determinism
- No stochastic components added at API layer. Orchestrator remains seed-aware.

## Validation & Errors
- Consistent 404 for missing manifests/metrics; /runs returns empty list if registry missing.

## Local CI gate status
- uv run ruff/black/mypy/pytest run locally and pass for API + tests.
  - ruff: OK
  - black --check: OK
  - mypy (processes/api): OK
  - pytest: tests/test_api_endpoints.py + existing API tests pass

## Rollback plan
- Revert this PR; endpoints are additive and isolated to API layer.
