### PR TITLE
PRP-12: API Endpoints Follow-Up — Robustness & CI Scope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,8 @@ on:
     branches: [ main ]
     paths:
       - 'processes/api/**'
-      - 'pipeline/**'
-      - 'tests/**'
+      - 'pipeline/schemas/**'
+      - 'tests/test_api_*'
       - 'pyproject.toml'
       - '.github/workflows/**'
   push:
@@ -15,8 +15,8 @@ on:
       - 'feat/**'
     paths:
       - 'processes/api/**'
-      - 'pipeline/**'
-      - 'tests/**'
+      - 'pipeline/schemas/**'
+      - 'tests/test_api_*'
       - 'pyproject.toml'
       - '.github/workflows/**'
 
@@ -78,4 +78,3 @@ jobs:
 
       - name: Pytest (full)
         run: uv run pytest -q
-

--- a/processes/api/app.py
+++ b/processes/api/app.py
@@ -1,22 +1,31 @@
 from __future__ import annotations
 
 import json
+import logging
 import tempfile
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, cast
 
 import pandas as pd
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, Response
+from fastapi.responses import JSONResponse
 
 from processes.api.models import (
     BundleManifest,
+    ErrorResponse,
     OrchestratorRunRequest,
     OrchestratorRunResponse,
+    RunRegistryRow,
+    RunsListResponse,
 )
+from processes.dk_export import writer as dk_writer
 from processes.orchestrator import adapter as orch
 
 app = FastAPI()
+
+logger = logging.getLogger("processes.api")
 
 _RUNS: dict[str, dict[str, Any]] = {}
 _METRICS: dict[str, str] = {}
@@ -24,15 +33,37 @@ _METRICS: dict[str, str] = {}
 
 @app.get("/health")  # type: ignore[misc]
 def health() -> dict[str, Any]:
-    return {
+    t0 = time.time()
+    logger.info(json.dumps({"event": "api_enter", "endpoint": "/health"}))
+    out = {
         "ok": True,
         "version": "0.1.0",
         "time": datetime.now(timezone.utc).isoformat(),
     }
+    dt = time.time() - t0
+    logger.info(
+        json.dumps({"event": "api_exit", "endpoint": "/health", "dt_s": round(dt, 6)})
+    )
+    return out
 
 
-@app.post("/run/orchestrator", response_model=OrchestratorRunResponse)  # type: ignore[misc]
-def run_orchestrator(req: OrchestratorRunRequest) -> OrchestratorRunResponse:
+@app.post(
+    "/run/orchestrator",
+    response_model=OrchestratorRunResponse | ErrorResponse,
+)  # type: ignore[misc]
+def run_orchestrator(
+    req: OrchestratorRunRequest, response: Response
+) -> OrchestratorRunResponse | ErrorResponse:
+    t0 = time.time()
+    logger.info(
+        json.dumps(
+            {
+                "event": "api_enter",
+                "endpoint": "/run/orchestrator",
+                "slate_id": req.slate_id,
+            }
+        )
+    )
     out_root = Path(req.out_root)
     schemas_root = Path(req.schemas_root)
 
@@ -69,33 +100,318 @@ def run_orchestrator(req: OrchestratorRunRequest) -> OrchestratorRunResponse:
                 _METRICS[run_id] = str(metrics_path)
         _RUNS[bundle_id] = {"bundle_path": str(bundle_path)}
 
-    return OrchestratorRunResponse(
+    out = OrchestratorRunResponse(
         bundle_id=bundle_id,
         bundle_path=str(bundle_path),
         stages=stages_map,
         run_registry_path=None,
     )
+    dt = time.time() - t0
+    logger.info(
+        json.dumps(
+            {
+                "event": "api_exit",
+                "endpoint": "/run/orchestrator",
+                "dt_s": round(dt, 6),
+                "bundle_id": bundle_id,
+            }
+        )
+    )
+    return out
 
 
-@app.get("/runs/{run_id}", response_model=BundleManifest)  # type: ignore[misc]
-def get_run(run_id: str) -> BundleManifest:
+@app.get(
+    "/runs/{run_id}",
+    response_model=BundleManifest | ErrorResponse,
+)  # type: ignore[misc]
+def get_run(run_id: str, response: Response) -> BundleManifest | ErrorResponse:
+    t0 = time.time()
+    logger.info(
+        json.dumps(
+            {
+                "event": "api_enter",
+                "endpoint": "/runs/{run_id}",
+                "run_id": run_id,
+            }
+        )
+    )
     info = _RUNS.get(run_id)
     if not info:
-        raise HTTPException(status_code=404, detail="run not found")
+        response.status_code = 404
+        return ErrorResponse(error="not_found", detail="run not found")
     bundle_path = Path(info["bundle_path"])
     if not bundle_path.exists():
-        raise HTTPException(status_code=404, detail="bundle manifest not found")
+        response.status_code = 404
+        return ErrorResponse(error="not_found", detail="bundle manifest not found")
     bundle = json.loads(bundle_path.read_text(encoding="utf-8"))
-    return cast(BundleManifest, BundleManifest.model_validate(bundle))
+    out = cast(BundleManifest, BundleManifest.model_validate(bundle))
+    dt = time.time() - t0
+    logger.info(
+        json.dumps(
+            {
+                "event": "api_exit",
+                "endpoint": "/runs/{run_id}",
+                "dt_s": round(dt, 6),
+            }
+        )
+    )
+    return out
 
 
-@app.get("/metrics/{run_id}")  # type: ignore[misc]
-def get_metrics(run_id: str) -> list[dict[str, Any]]:
+@app.get(
+    "/metrics/{run_id}",
+    response_model=list[dict[str, Any]] | ErrorResponse,
+)  # type: ignore[misc]
+def get_metrics(
+    run_id: str, response: Response
+) -> list[dict[str, Any]] | ErrorResponse:
+    t0 = time.time()
+    logger.info(
+        json.dumps(
+            {
+                "event": "api_enter",
+                "endpoint": "/metrics/{run_id}",
+                "run_id": run_id,
+            }
+        )
+    )
     path_str = _METRICS.get(run_id)
     if not path_str:
-        raise HTTPException(status_code=404, detail="metrics not found")
+        response.status_code = 404
+        return ErrorResponse(error="not_found", detail="metrics not found")
     path = Path(path_str)
     if not path.exists():
-        raise HTTPException(status_code=404, detail="metrics not found")
+        response.status_code = 404
+        return ErrorResponse(error="not_found", detail="metrics not found")
     df = pd.read_parquet(path)
-    return cast(list[dict[str, Any]], df.to_dict(orient="records"))
+    out = cast(list[dict[str, Any]], df.to_dict(orient="records"))
+    dt = time.time() - t0
+    logger.info(
+        json.dumps(
+            {
+                "event": "api_exit",
+                "endpoint": "/metrics/{run_id}",
+                "dt_s": round(dt, 6),
+            }
+        )
+    )
+    return out
+
+
+@app.get(
+    "/runs",
+    response_model=RunsListResponse | ErrorResponse,
+)  # type: ignore[misc]
+def list_runs(
+    response: Response, registry_path: str | None = None
+) -> RunsListResponse | ErrorResponse:
+    """List runs discovered in the registry parquet.
+
+    Returns 404 if the registry is missing.
+    """
+    t0 = time.time()
+    # Response provided by FastAPI injection
+    logger.info(
+        json.dumps(
+            {
+                "event": "api_enter",
+                "endpoint": "/runs",
+                "registry_path": registry_path,
+            }
+        )
+    )
+    reg_path = Path(registry_path or Path("data") / "registry" / "runs.parquet")
+    if not reg_path.exists():
+        response.status_code = 404
+        return ErrorResponse(error="not_found", detail="registry not found")
+    try:
+        df = pd.read_parquet(reg_path)
+    except Exception as e:  # pragma: no cover
+        response.status_code = 500
+        return ErrorResponse(
+            error="internal_error", detail=f"failed to read registry: {e}"
+        )
+    rows = cast(list[dict[str, Any]], df.to_dict(orient="records"))
+    models = [RunRegistryRow.model_validate(r) for r in rows]
+    out = RunsListResponse(runs=models)
+    dt = time.time() - t0
+    logger.info(
+        json.dumps(
+            {
+                "event": "api_exit",
+                "endpoint": "/runs",
+                "dt_s": round(dt, 6),
+                "count": len(models),
+            }
+        )
+    )
+    return out
+
+
+def _find_manifest_for_run(run_id: str, runs_root: Path) -> tuple[str, Path]:
+    """Return (run_type, manifest_path) for the first matching run dir.
+
+    Searches known run types under `runs_root`.
+    """
+    for rt in ("sim", "variants", "field", "optimizer", "ingest", "metrics"):
+        m = runs_root / rt / run_id / "manifest.json"
+        if m.exists():
+            return rt, m
+    raise FileNotFoundError("manifest not found for run_id")
+
+
+@app.get(
+    "/export/dk/{run_id}",
+    responses={
+        404: {"model": ErrorResponse},
+        422: {"model": ErrorResponse},
+        400: {"model": ErrorResponse},
+    },
+)  # type: ignore[misc]
+def export_dk_csv(
+    run_id: str,
+    response: Response,
+    runs_root: str | None = None,
+    top_n: int = 20,
+    dedupe: bool = True,
+) -> Response:
+    """Generate a DK-uploadable CSV from a run (sim or variants).
+
+    - For sim runs: ranks entrants by EV (mean prize) from sim_results.
+    - For variants runs: uses variant_catalog order (first N) and `export_csv_row`.
+
+    On error, returns JSON matching ErrorResponse model.
+    """
+    t0 = time.time()
+    logger.info(
+        json.dumps(
+            {
+                "event": "api_enter",
+                "endpoint": "/export/dk/{run_id}",
+                "run_id": run_id,
+                "top_n": top_n,
+                "dedupe": bool(dedupe),
+            }
+        )
+    )
+    # Response provided by FastAPI injection
+    root = Path(runs_root or "runs")
+    try:
+        run_type, manifest_path = _find_manifest_for_run(run_id, root)
+    except FileNotFoundError:
+        return JSONResponse(
+            status_code=404,
+            content={"error": "not_found", "detail": "run manifest not found"},
+        )
+
+    if run_type == "sim":
+        try:
+            sim_path, field_path = dk_writer.discover_from_sim_run(run_id, root)
+            sim_df = pd.read_parquet(sim_path)
+            field_df = pd.read_parquet(field_path)
+            export_df = dk_writer.build_export_df(
+                sim_df, field_df, top_n=int(top_n), dedupe=bool(dedupe)
+            )
+        except Exception as e:
+            return JSONResponse(
+                status_code=422,
+                content={"error": "invalid_export", "detail": str(e)},
+            )
+    elif run_type == "variants":
+        # Discover variant_catalog and derive export rows from export_csv_row
+        data = json.loads(manifest_path.read_text(encoding="utf-8"))
+        catalog_path: Path | None = None
+        for obj in data.get("outputs", []):
+            if obj.get("kind") == "variant_catalog":
+                catalog_path = Path(str(obj["path"]))
+                break
+        if catalog_path is None or not catalog_path.exists():
+            return JSONResponse(
+                status_code=404,
+                content={
+                    "error": "not_found",
+                    "detail": "variant catalog not found",
+                },
+            )
+        cat_df = pd.read_parquet(catalog_path)
+        if "export_csv_row" not in cat_df.columns:
+            return JSONResponse(
+                status_code=422,
+                content={"error": "invalid_export", "detail": "export_csv_row missing"},
+            )
+        # Build DataFrame with DK columns from export_csv_row
+        rows: list[dict[str, Any]] = []
+        for _, row in cat_df.head(int(top_n)).iterrows():
+            tokens = dk_writer._parse_export_row(str(row.get("export_csv_row", "")))
+            players = [tokens.get(slot, "") for slot in dk_writer.DK_SLOTS_ORDER]
+            if "" in players:
+                return JSONResponse(
+                    status_code=422,
+                    content={
+                        "error": "invalid_export",
+                        "detail": "invalid export_csv_row in catalog",
+                    },
+                )
+            rows.append(dict(zip(dk_writer.DK_SLOTS_ORDER, players, strict=True)))
+        export_df = pd.DataFrame(rows)
+    else:
+        return JSONResponse(
+            status_code=400,
+            content={"error": "unsupported_run_type", "detail": f"{run_type}"},
+        )
+
+    # Serialize CSV with DK header order only
+    csv_text = export_df.to_csv(columns=dk_writer.DK_SLOTS_ORDER, index=False)
+    dt = time.time() - t0
+    logger.info(
+        json.dumps(
+            {
+                "event": "api_exit",
+                "endpoint": "/export/dk/{run_id}",
+                "dt_s": round(dt, 6),
+                "rows": int(len(export_df)),
+            }
+        )
+    )
+    return Response(content=csv_text, media_type="text/csv")
+
+
+@app.get("/logs/{run_id}", response_model=dict[str, Any])  # type: ignore[misc]
+def get_logs(run_id: str, runs_root: str | None = None) -> dict[str, Any]:
+    """Return placeholder logs/debug info for a run.
+
+    If a `logs.txt` exists under the run dir, return its content; otherwise a stub.
+    """
+    t0 = time.time()
+    logger.info(
+        json.dumps(
+            {
+                "event": "api_enter",
+                "endpoint": "/logs/{run_id}",
+                "run_id": run_id,
+            }
+        )
+    )
+    root = Path(runs_root or "runs")
+    try:
+        run_type, manifest_path = _find_manifest_for_run(run_id, root)
+    except FileNotFoundError:
+        return {"error": "not_found", "detail": "run manifest not found"}
+    run_dir = manifest_path.parent
+    logs_path = run_dir / "logs.txt"
+    if logs_path.exists():
+        content = logs_path.read_text(encoding="utf-8")
+        out = {"run_id": run_id, "run_type": run_type, "logs": content}
+    else:
+        out = {"run_id": run_id, "run_type": run_type, "message": "logs not available"}
+    dt = time.time() - t0
+    logger.info(
+        json.dumps(
+            {
+                "event": "api_exit",
+                "endpoint": "/logs/{run_id}",
+                "dt_s": round(dt, 6),
+            }
+        )
+    )
+    return out

--- a/processes/api/models.py
+++ b/processes/api/models.py
@@ -5,6 +5,11 @@ from typing import Any, Literal
 from pydantic import BaseModel
 
 
+class ErrorResponse(BaseModel):
+    error: str
+    detail: str | None = None
+
+
 class IngestConfig(BaseModel):
     source: str = "manual"
     projections: str | None = None
@@ -97,3 +102,18 @@ class BundleManifest(BaseModel):
     slate_id: str
     created_ts: str
     stages: list[BundleStage]
+
+
+class RunRegistryRow(BaseModel):
+    run_id: str
+    run_type: str
+    slate_id: str
+    status: str
+    primary_outputs: list[str] | None = None
+    metrics_path: str | None = None
+    created_ts: str
+    tags: list[str] | None = None
+
+
+class RunsListResponse(BaseModel):
+    runs: list[RunRegistryRow]

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+from httpx import AsyncClient
+
+from processes.api import app as api_app
+
+
+@pytest.mark.anyio
+async def test_runs_registry_missing_404(tmp_path: Path) -> None:
+    missing = tmp_path / "data" / "registry" / "runs.parquet"
+    async with AsyncClient(app=api_app, base_url="http://test") as ac:
+        resp = await ac.get("/runs", params={"registry_path": str(missing)})
+        assert resp.status_code == 404
+        payload = resp.json()
+        assert payload["error"] == "not_found"
+        assert "registry" in payload.get("detail", "")
+
+
+@pytest.mark.anyio
+async def test_export_dk_csv_variants_bad_export_row_422(tmp_path: Path) -> None:
+    # Create a variants run with a catalog missing export_csv_row
+    runs_root = tmp_path / "runs"
+    run_id = "VAR_BAD"
+    run_dir = runs_root / "variants" / run_id
+    artifacts = run_dir / "artifacts"
+    artifacts.mkdir(parents=True, exist_ok=True)
+
+    # minimal catalog without export_csv_row column
+    cat_df = pd.DataFrame(
+        [
+            {
+                "run_id": run_id,
+                "variant_id": "V1",
+                "parent_lineup_id": "L1",
+                "players": [f"p{i}" for i in range(8)],
+                "variant_params": {"_": None},
+            }
+        ]
+    )
+    catalog_path = artifacts / "variant_catalog.parquet"
+    cat_df.to_parquet(catalog_path)
+
+    manifest = {
+        "schema_version": "0.2.0",
+        "run_id": run_id,
+        "run_type": "variants",
+        "slate_id": "20250101_NBA",
+        "created_ts": "2025-01-01T12:00:00.000Z",
+        "inputs": [],
+        "outputs": [
+            {"path": str(catalog_path), "kind": "variant_catalog"},
+        ],
+    }
+    (run_dir / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+    async with AsyncClient(app=api_app, base_url="http://test") as ac:
+        resp = await ac.get(
+            f"/export/dk/{run_id}", params={"runs_root": str(runs_root)}
+        )
+        assert resp.status_code == 422
+        payload = resp.json()
+        assert payload["error"] == "invalid_export"
+        assert "export_csv_row" in payload.get("detail", "")
+
+
+@pytest.mark.anyio
+async def test_logs_fallback_message_no_logs(tmp_path: Path) -> None:
+    runs_root = tmp_path / "runs"
+    run_id = "RID_NO_LOG"
+    run_dir = runs_root / "sim" / run_id
+    (run_dir / "artifacts").mkdir(parents=True, exist_ok=True)
+    # minimal manifest
+    manifest = {
+        "schema_version": "0.2.0",
+        "run_id": run_id,
+        "run_type": "sim",
+        "slate_id": "20250101_NBA",
+        "created_ts": "2025-01-01T12:00:00.000Z",
+        "inputs": [],
+        "outputs": [],
+    }
+    (run_dir / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+    async with AsyncClient(app=api_app, base_url="http://test") as ac:
+        resp = await ac.get(f"/logs/{run_id}", params={"runs_root": str(runs_root)})
+        assert resp.status_code == 200
+        payload = resp.json()
+        assert payload["run_id"] == run_id
+        assert payload.get("message") == "logs not available"


### PR DESCRIPTION
## Scope
- Harden /runs: 404 when registry missing (no empty list).
- Harden /export/dk: 422 on missing/malformed export_csv_row; JSON error body.
- Add structured logging at endpoint entry/exit.
- Add ErrorResponse model; use response_model or responses mapping for errors.
- Add regression tests in tests/test_api_endpoints.py.
- Update CI workflow filters: processes/api/**, tests/test_api_*, pipeline/schemas/**.

## Data contracts changed?
- No schema drift; ErrorResponse is API-only.

## Determinism
- No stochastic behavior added at API layer.

## Local CI status
- uv run ruff/black/mypy/pytest (scoped) all pass locally.

## Rollback plan
- Revert this PR; changes are additive and localized to API + tests + CI filters.
