### PR TITLE
fix(ui): table own_sum error; gate dev toggles; run spinner; heading rename

### DIFF
--- a/components/ui/ControlsBar.tsx
+++ b/components/ui/ControlsBar.tsx
@@ -14,7 +14,7 @@ export default function ControlsBar({
   onGridModeChange?: (m: GridMode) => void;
 }) {
   const { status, run, reset, options, setOptions, runSolve } = useRunStore();
-  const showDev = process.env.NODE_ENV !== "production" && onGridModeChange;
+  const showDev = process.env.NEXT_PUBLIC_DEV_UI === "true" && onGridModeChange;
 
   // New UX controls state
   const [nLineups, setNLineups] = useState<number>(5);
@@ -59,7 +59,7 @@ export default function ControlsBar({
 
   return (
     <div className="h-auto w-full border-t border-border px-4 py-3 flex flex-col gap-3 bg-background">
-      <div className="text-sm font-medium opacity-80">Controls / Knobs</div>
+      <div className="text-sm font-medium opacity-80">Optimizer Settings</div>
       <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-2 items-end">
         <div>
           <label className="block text-[11px] opacity-70 mb-1">Seed</label>
@@ -228,7 +228,26 @@ export default function ControlsBar({
         <div />
       )}
       <div className="flex gap-2 justify-end">
-        <Button onClick={onRunClick} disabled={status === "running"}>Run</Button>
+        <Button onClick={onRunClick} disabled={status === "running"}>
+          {status === "running" ? (
+            <span className="inline-flex items-center gap-2">
+              {/* lucide-react loader */}
+              <svg
+                className="animate-spin h-4 w-4"
+                viewBox="0 0 24 24"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                aria-hidden
+              >
+                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
+              </svg>
+              Running…
+            </span>
+          ) : (
+            "Run"
+          )}
+        </Button>
         <Button variant="outline" onClick={() => reset()} disabled={status === "running"}>
           Reset
         </Button>

--- a/e2e/lineup-table.spec.ts
+++ b/e2e/lineup-table.spec.ts
@@ -1,0 +1,257 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Lineup Table Features', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/optimizer');
+  });
+
+  test('should display RunSummary metrics with correct formatting', async ({ page }) => {
+    // Wait for the run summary to be visible
+    await expect(page.getByTestId('run-summary')).toBeVisible();
+    
+    // Check for badge tooltips
+    const engineBadge = page.getByTestId('engine-badge');
+    if (await engineBadge.isVisible()) {
+      await engineBadge.hover();
+      await expect(page.getByText('Optimization engine used')).toBeVisible();
+    }
+
+    // Check for inputs/outputs card
+    const inputsCard = page.getByTestId('inputs-outputs-card');
+    if (await inputsCard.isVisible()) {
+      // Verify number formatting with proper separators
+      const lineupsValue = inputsCard.locator('dd').first();
+      await expect(lineupsValue).toHaveClass(/font-mono tabular-nums/);
+    }
+
+    // Check for performance card metrics
+    const perfCard = page.getByTestId('performance-card');
+    if (await perfCard.isVisible()) {
+      // Check that scores are formatted with 2 decimal places
+      const scoreElements = perfCard.locator('dd');
+      const scoreText = await scoreElements.first().textContent();
+      if (scoreText && scoreText !== '—') {
+        expect(scoreText).toMatch(/^\d{1,3}(,\d{3})*\.\d{2}$/);
+      }
+    }
+  });
+
+  test('should switch between Cards and Table views', async ({ page }) => {
+    // Check that view tabs are present
+    await expect(page.getByTestId('lineup-view-tabs')).toBeVisible();
+    await expect(page.getByTestId('cards-tab')).toBeVisible();
+    await expect(page.getByTestId('table-tab')).toBeVisible();
+
+    // Start with Cards view (default)
+    await expect(page.getByTestId('cards-view')).toBeVisible();
+    await expect(page.getByTestId('table-view')).not.toBeVisible();
+
+    // Switch to Table view
+    await page.getByTestId('table-tab').click();
+    await expect(page.getByTestId('table-view')).toBeVisible();
+    await expect(page.getByTestId('cards-view')).not.toBeVisible();
+
+    // Switch back to Cards view
+    await page.getByTestId('cards-tab').click();
+    await expect(page.getByTestId('cards-view')).toBeVisible();
+    await expect(page.getByTestId('table-view')).not.toBeVisible();
+  });
+
+  test('should sort table by Score and manage columns', async ({ page }) => {
+    // Switch to table view first
+    await page.getByTestId('table-tab').click();
+    
+    // Wait for table to load
+    const table = page.getByTestId('lineup-table-card');
+    await expect(table).toBeVisible();
+
+    // Check default sorting by Score (descending)
+    const scoreHeader = page.getByTestId('header-score');
+    if (await scoreHeader.isVisible()) {
+      await expect(scoreHeader).toContainText('↓');
+    }
+
+    // Open column settings
+    await page.getByTestId('column-settings-button').click();
+    
+    // Toggle Salary column off
+    const salaryToggle = page.getByTestId('column-toggle-salary_used');
+    if (await salaryToggle.isVisible()) {
+      await salaryToggle.click();
+      
+      // Verify salary column is hidden
+      const salaryHeader = page.getByTestId('header-salary_used');
+      await expect(salaryHeader).not.toBeVisible();
+      
+      // Toggle it back on
+      await page.getByTestId('column-settings-button').click();
+      await salaryToggle.click();
+      await expect(salaryHeader).toBeVisible();
+    }
+
+    // Test column pinning
+    await page.getByTestId('column-settings-button').click();
+    const scorePinToggle = page.getByTestId('column-pin-score');
+    if (await scorePinToggle.isVisible()) {
+      await scorePinToggle.click();
+      // Check that pinning state is reflected (should show "Pinned" badge)
+      await expect(page.getByText('Pinned')).toBeVisible();
+    }
+  });
+
+  test('should search for players by name and ID', async ({ page }) => {
+    // Switch to table view
+    await page.getByTestId('table-tab').click();
+    
+    const searchInput = page.getByTestId('lineup-search-input');
+    await expect(searchInput).toBeVisible();
+
+    // Test search by player ID (assuming some test data exists)
+    await searchInput.fill('12345');
+    
+    // Verify that search filters are applied
+    const rowCountBadge = page.getByTestId('row-count-badge');
+    await expect(rowCountBadge).toBeVisible();
+    
+    // Clear search
+    await searchInput.fill('');
+    
+    // Test search by player name
+    await searchInput.fill('LeBron');
+    
+    // The filtering should work with any existing data
+    await expect(rowCountBadge).toBeVisible();
+    
+    // Clear search again
+    await searchInput.fill('');
+  });
+
+  test('should export CSV with correct headers and data', async ({ page }) => {
+    // Switch to table view
+    await page.getByTestId('table-tab').click();
+    
+    // Wait for table to be ready
+    await expect(page.getByTestId('lineup-table-card')).toBeVisible();
+    
+    // Set up download listener
+    const downloadPromise = page.waitForEvent('download');
+    
+    // Click export button
+    const exportButton = page.getByTestId('export-csv-button');
+    await expect(exportButton).toBeVisible();
+    await expect(exportButton).toBeEnabled();
+    
+    await exportButton.click();
+    
+    // Wait for download to start
+    const download = await downloadPromise;
+    
+    // Verify filename format
+    const filename = download.suggestedFilename();
+    expect(filename).toMatch(/^lineups-export-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}\.csv$/);
+  });
+
+  test('should reset table settings', async ({ page }) => {
+    // Switch to table view
+    await page.getByTestId('table-tab').click();
+    
+    // Make some changes first
+    const searchInput = page.getByTestId('lineup-search-input');
+    await searchInput.fill('test search');
+    
+    // Open column settings and make a change
+    await page.getByTestId('column-settings-button').click();
+    const firstToggle = page.locator('[data-testid^="column-toggle-"]').first();
+    if (await firstToggle.isVisible()) {
+      await firstToggle.click();
+    }
+    
+    // Press escape to close dropdown
+    await page.keyboard.press('Escape');
+    
+    // Reset everything
+    await page.getByTestId('reset-button').click();
+    
+    // Verify search is cleared
+    await expect(searchInput).toHaveValue('');
+    
+    // Verify columns are restored (would need to check specific implementation)
+    await expect(page.getByTestId('column-settings-button')).toBeVisible();
+  });
+
+  test('should show correct row counts in badge', async ({ page }) => {
+    // Switch to table view
+    await page.getByTestId('table-tab').click();
+    
+    const rowCountBadge = page.getByTestId('row-count-badge');
+    await expect(rowCountBadge).toBeVisible();
+    
+    // Initial state should show total count
+    const initialText = await rowCountBadge.textContent();
+    expect(initialText).toMatch(/\d+ rows?/);
+    
+    // Apply search filter
+    const searchInput = page.getByTestId('lineup-search-input');
+    await searchInput.fill('xyz_nonexistent_player');
+    
+    // Should show filtered count
+    await expect(rowCountBadge).toContainText('0 of');
+    
+    // Clear search
+    await searchInput.fill('');
+    
+    // Should return to total count
+    await expect(rowCountBadge).toContainText('rows');
+  });
+
+  test('should handle empty table state', async ({ page }) => {
+    // Go to table view when no data is loaded
+    await page.getByTestId('table-tab').click();
+    
+    // Should show appropriate empty state
+    const noResultsCell = page.getByTestId('no-results-cell');
+    if (await noResultsCell.isVisible()) {
+      await expect(noResultsCell).toContainText('No results found');
+    }
+  });
+
+  test('should display player cells with copy functionality', async ({ page }) => {
+    // Switch to table view
+    await page.getByTestId('table-tab').click();
+    
+    // Look for player cells
+    const playerCells = page.locator('[data-testid^="player-cell-"]');
+    const firstPlayerCell = playerCells.first();
+    
+    if (await firstPlayerCell.isVisible()) {
+      // Check for copy button
+      const copyButton = firstPlayerCell.locator('[data-testid^="copy-player-"]');
+      if (await copyButton.isVisible()) {
+        await copyButton.click();
+        // Note: Actually testing clipboard would require additional permissions
+      }
+      
+      // Test tooltip on hover
+      await firstPlayerCell.hover();
+      // Tooltip content would appear - specific checks depend on data
+    }
+  });
+
+  test('should not log console errors when toggling views', async ({ page }) => {
+    const errors: string[] = [];
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') errors.push(msg.text());
+    });
+
+    await page.getByTestId('table-tab').click();
+    await page.getByTestId('cards-tab').click();
+
+    expect(errors).toEqual([]);
+  });
+
+  test('dev-only grid state toggles are hidden by default', async ({ page }) => {
+    // When NEXT_PUBLIC_DEV_UI !== 'true', the dev toggles should not render
+    const devToggles = page.locator('[aria-label="Dev grid state toggles"]');
+    await expect(devToggles).toHaveCount(0);
+  });
+});

--- a/lib/table/columns.tsx
+++ b/lib/table/columns.tsx
@@ -1,0 +1,309 @@
+import { ColumnDef } from "@tanstack/react-table";
+import { Copy } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { useRosterMap, type PlayerInfo } from "@/hooks/useRosterMap";
+
+// Extended lineup type with additional metrics from PRP requirements
+export interface LineupTableData {
+  lineup_id: string;
+  score: number;
+  salary_used: number;
+  salary_left?: number;
+  dup_risk?: number;
+  own_sum?: number;
+  own_avg?: number;
+  lev_sum?: number;
+  lev_avg?: number;
+  num_uniques_in_pool?: number;
+  teams_used?: string[] | number;
+  proj_pts_sum?: number;
+  stack_flags?: string;
+  
+  // Player slots
+  PG?: string;
+  SG?: string;
+  SF?: string;
+  PF?: string;
+  C?: string;
+  G?: string;
+  F?: string;
+  UTIL?: string;
+}
+
+// Copy ID button component
+const CopyIdButton = ({ playerId }: { playerId: string }) => {
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(playerId);
+      // Could add toast notification here
+    } catch (err) {
+      console.error("Failed to copy:", err);
+    }
+  };
+
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      className="h-4 w-4 p-0 ml-1"
+      onClick={handleCopy}
+      data-testid={`copy-player-${playerId}`}
+    >
+      <Copy className="h-3 w-3" />
+      <span className="sr-only">Copy player ID</span>
+    </Button>
+  );
+};
+
+// Player cell component with name and ID
+const PlayerCell = ({ playerId, playerInfo }: { playerId: string; playerInfo?: PlayerInfo }) => {
+  const displayName = playerInfo?.name || "";
+  const hasName = displayName && displayName.trim().length > 0;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div className="text-left" data-testid={`player-cell-${playerId}`}>
+          {hasName ? (
+            <>
+              <div className="font-medium truncate">{displayName}</div>
+              <div className="text-xs text-muted-foreground flex items-center">
+                ({playerId})
+                <CopyIdButton playerId={playerId} />
+              </div>
+            </>
+          ) : (
+            <div className="font-medium flex items-center">
+              {playerId}
+              <CopyIdButton playerId={playerId} />
+            </div>
+          )}
+        </div>
+      </TooltipTrigger>
+      <TooltipContent>
+        <div>
+          {hasName ? (
+            <>
+              <p className="font-medium">{displayName}</p>
+              <p className="text-xs text-muted-foreground">
+                {playerInfo?.team && playerInfo?.pos ? `${playerInfo.team} - ${playerInfo.pos}` : ""}
+              </p>
+              <p className="text-xs">ID: {playerId}</p>
+            </>
+          ) : (
+            <p>Player ID: {playerId}<br />Name unavailable</p>
+          )}
+        </div>
+      </TooltipContent>
+    </Tooltip>
+  );
+};
+
+// Number formatters
+const formatScore = (value: number) => 
+  new Intl.NumberFormat("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(value);
+
+const formatSalary = (value: number) => 
+  new Intl.NumberFormat("en-US").format(value);
+
+const formatPercentage = (value: number) => 
+  new Intl.NumberFormat("en-US", { style: "percent", minimumFractionDigits: 1 }).format(value);
+
+const formatDecimal3 = (value: number) => 
+  new Intl.NumberFormat("en-US", { minimumFractionDigits: 3, maximumFractionDigits: 3 }).format(value);
+
+export const createLineupColumns = (rosterMap: Record<string, PlayerInfo> = {}): ColumnDef<LineupTableData>[] => [
+  {
+    accessorKey: "lineup_id",
+    header: "ID",
+    size: 80,
+    cell: ({ getValue }) => (
+      <div className="font-mono text-xs" data-testid="lineup-id-cell">
+        {String(getValue()).slice(-8)}
+      </div>
+    ),
+  },
+  {
+    accessorKey: "score",
+    header: "Score",
+    size: 80,
+    cell: ({ getValue }) => (
+      <div className="font-mono tabular-nums text-right" data-testid="score-cell">
+        {formatScore(Number(getValue()))}
+      </div>
+    ),
+  },
+  {
+    accessorKey: "salary_used",
+    header: "Salary",
+    size: 80,
+    cell: ({ getValue }) => (
+      <div className="font-mono tabular-nums text-right" data-testid="salary-cell">
+        {formatSalary(Number(getValue()))}
+      </div>
+    ),
+  },
+  {
+    accessorKey: "salary_left",
+    header: "Left",
+    size: 60,
+    cell: ({ getValue }) => {
+      const value = getValue();
+      return (
+        <div className="font-mono tabular-nums text-right text-xs" data-testid="salary-left-cell">
+          {value !== undefined ? formatSalary(Number(value)) : "—"}
+        </div>
+      );
+    },
+  },
+  {
+    accessorKey: "dup_risk",
+    header: "Dup Risk",
+    size: 80,
+    cell: ({ getValue }) => {
+      const value = getValue();
+      return (
+        <div className="font-mono tabular-nums text-right" data-testid="dup-risk-cell">
+          {value !== undefined ? formatPercentage(Number(value)) : "—"}
+        </div>
+      );
+    },
+  },
+  {
+    accessorKey: "own_avg",
+    header: "Own %",
+    size: 80,
+    cell: ({ getValue, row }) => {
+      const avg = getValue();
+      // Avoid accessing a non-declared column via row.getValue("own_sum").
+      // Read directly from the original row to prevent console errors.
+      const raw: any = row.original as any;
+      const sum = raw?.own_sum;
+      const value = avg !== undefined ? avg : sum !== undefined ? Number(sum) / 8 : undefined;
+      return (
+        <div className="font-mono tabular-nums text-right" data-testid="ownership-cell">
+          {value !== undefined ? formatPercentage(Number(value)) : "—"}
+        </div>
+      );
+    },
+  },
+  {
+    accessorKey: "num_uniques_in_pool",
+    header: "Uniques",
+    size: 80,
+    cell: ({ getValue }) => {
+      const value = getValue();
+      return (
+        <div className="font-mono tabular-nums text-right" data-testid="uniques-cell">
+          {value !== undefined ? formatSalary(Number(value)) : "—"}
+        </div>
+      );
+    },
+  },
+  {
+    accessorKey: "teams_used",
+    header: "Teams",
+    size: 60,
+    cell: ({ getValue }) => {
+      const value = getValue();
+      let count: number;
+      let teamsList: string[] = [];
+
+      if (Array.isArray(value)) {
+        count = value.length;
+        teamsList = value;
+      } else if (typeof value === "number") {
+        count = value;
+      } else {
+        count = 0;
+      }
+
+      return (
+        <Tooltip>
+          <TooltipTrigger>
+            <div className="font-mono tabular-nums text-right cursor-default" data-testid="teams-cell">
+              {count}
+            </div>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>{teamsList.length > 0 ? `Teams: ${teamsList.join(", ")}` : `${count} teams used`}</p>
+          </TooltipContent>
+        </Tooltip>
+      );
+    },
+  },
+  // Player position columns
+  {
+    accessorKey: "PG",
+    header: "PG",
+    size: 140,
+    cell: ({ getValue }) => {
+      const playerId = String(getValue() || "");
+      return playerId ? <PlayerCell playerId={playerId} playerInfo={rosterMap[playerId]} /> : null;
+    },
+  },
+  {
+    accessorKey: "SG", 
+    header: "SG",
+    size: 140,
+    cell: ({ getValue }) => {
+      const playerId = String(getValue() || "");
+      return playerId ? <PlayerCell playerId={playerId} playerInfo={rosterMap[playerId]} /> : null;
+    },
+  },
+  {
+    accessorKey: "SF",
+    header: "SF", 
+    size: 140,
+    cell: ({ getValue }) => {
+      const playerId = String(getValue() || "");
+      return playerId ? <PlayerCell playerId={playerId} playerInfo={rosterMap[playerId]} /> : null;
+    },
+  },
+  {
+    accessorKey: "PF",
+    header: "PF",
+    size: 140,
+    cell: ({ getValue }) => {
+      const playerId = String(getValue() || "");
+      return playerId ? <PlayerCell playerId={playerId} playerInfo={rosterMap[playerId]} /> : null;
+    },
+  },
+  {
+    accessorKey: "C",
+    header: "C",
+    size: 140,
+    cell: ({ getValue }) => {
+      const playerId = String(getValue() || "");
+      return playerId ? <PlayerCell playerId={playerId} playerInfo={rosterMap[playerId]} /> : null;
+    },
+  },
+  {
+    accessorKey: "G",
+    header: "G",
+    size: 140,
+    cell: ({ getValue }) => {
+      const playerId = String(getValue() || "");
+      return playerId ? <PlayerCell playerId={playerId} playerInfo={rosterMap[playerId]} /> : null;
+    },
+  },
+  {
+    accessorKey: "F",
+    header: "F",
+    size: 140,
+    cell: ({ getValue }) => {
+      const playerId = String(getValue() || "");
+      return playerId ? <PlayerCell playerId={playerId} playerInfo={rosterMap[playerId]} /> : null;
+    },
+  },
+  {
+    accessorKey: "UTIL",
+    header: "UTIL",
+    size: 140,
+    cell: ({ getValue }) => {
+      const playerId = String(getValue() || "");
+      return playerId ? <PlayerCell playerId={playerId} playerInfo={rosterMap[playerId]} /> : null;
+    },
+  },
+];


### PR DESCRIPTION
Implements the first pass of Optimizer Page UX audit fixes:\n\n- Fix table 'Own %' errors by reading own_sum from row.original to avoid TanStack column lookup on missing id\n- Gate dev-only grid state toggles behind NEXT_PUBLIC_DEV_UI flag\n- Rename "Controls / Knobs" to "Optimizer Settings"\n- Show spinner + disabled state on Run button while running\n- Add Playwright coverage: no console errors when toggling; dev toggles hidden by default\n\nScope: UI only. No schema or adapter changes.\nCI: Python tests pass locally via 'uv run pytest -q'.\n\nAcceptance:\n- Switching Cards↔Table produces no console errors\n- Dev toggles do not render unless NEXT_PUBLIC_DEV_UI=true\n- Run button shows spinner and skeletons render in results while running\n\nFollow-ups (tracked in planned PRs): sliders + tooltips, grouped settings, upload success UX, table polish, optional RunSummary placement.