### PR TITLE
fix: preserve DK slot order in variant builder

### DIFF
--- a/src/variant_builder/__init__.py
+++ b/src/variant_builder/__init__.py
@@ -74,10 +74,12 @@ def build_variant_catalog(params: BuildParams) -> Path:
 
     params.output_path.parent.mkdir(parents=True, exist_ok=True)
     with params.output_path.open("w", encoding="utf-8") as out:
+        slot_order = {slot: i for i, slot in enumerate(DK_SLOTS_ORDER)}
         for lineup in _load_optimizer_run(params.optimizer_run):
             if not validator.validate(lineup, pool_df):
                 raise ValueError("Invalid lineup in optimizer run")
-            player_ids = [pid for _, pid in lineup]
+            ordered = sorted(lineup, key=lambda pair: slot_order[pair[0]])
+            player_ids = [pid for _, pid in ordered]
             sub = pool.loc[player_ids]
             record = {
                 "lineup": player_ids,

--- a/tests/test_variant_builder_contract.py
+++ b/tests/test_variant_builder_contract.py
@@ -102,3 +102,30 @@ def test_invalid_lineup_raises(tmp_path: Path) -> None:
     )
     with pytest.raises(ValueError, match="Invalid lineup"):
         build_variant_catalog(params)
+
+
+def test_build_variant_catalog_reorders_slots(tmp_path: Path) -> None:
+    pool_path = _make_player_pool(tmp_path / "players.csv")
+    lineup = [
+        ("SG", "p1"),
+        ("PG", "p0"),
+        ("SF", "p2"),
+        ("PF", "p3"),
+        ("C", "p4"),
+        ("G", "p5"),
+        ("F", "p6"),
+        ("UTIL", "p7"),
+    ]
+    opt_path = _write_optimizer_run(tmp_path / "optimizer_run.jsonl", lineup)
+    out_path = tmp_path / "variant_catalog.jsonl"
+
+    params = BuildParams(
+        optimizer_run=opt_path,
+        player_pool=pool_path,
+        output_path=out_path,
+        slate_id="20250101_NBA",
+    )
+    build_variant_catalog(params)
+
+    rec = json.loads(out_path.read_text().strip())
+    assert rec["lineup"] == [f"p{i}" for i in range(8)]


### PR DESCRIPTION
## Summary
- reorder optimizer lineups to DraftKings slot order before serialization
- test variant builder to ensure slot ordering is preserved

## Testing
- `uv sync --dev`
- `uv run ruff check src/variant_builder/__init__.py tests/test_variant_builder_contract.py`
- `uv run black --check src/variant_builder/__init__.py tests/test_variant_builder_contract.py`
- `uv run mypy src/variant_builder/__init__.py tests/test_variant_builder_contract.py`
- `uv run pytest tests/test_variant_builder_contract.py`


------
https://chatgpt.com/codex/tasks/task_e_68bf94d37440832cb274a5596d2df5d5