### PR TITLE
fix: default to uniform weights when ownership absent

### DIFF
--- a/field_sampler/engine.py
+++ b/field_sampler/engine.py
@@ -73,7 +73,13 @@ class RejectionSampler:
             elig = elig[elig["team"].apply(self.teams.can_add)]
             if elig.empty:
                 return None
-            weights = elig.get("ownership").fillna(1.0).astype(float)
+            weights = (
+                elig["ownership"].astype(float).fillna(0.0).tolist()
+                if "ownership" in elig.columns
+                else [0.0] * len(elig)
+            )
+            if sum(weights) <= 0:
+                weights = [1.0] * len(weights)
             player = self.rng.choices(elig["player_id"].tolist(), weights=weights, k=1)[
                 0
             ]

--- a/tests/test_field_sampler_engine.py
+++ b/tests/test_field_sampler_engine.py
@@ -75,6 +75,20 @@ def test_salary_violation_rejected(tmp_path: Path) -> None:
         assert "bad" not in cast(list[str], row["players"])
 
 
+@pytest.mark.parametrize("drop", [True, False])  # type: ignore[misc]
+def test_uniform_weights_without_ownership(tmp_path: Path, drop: bool) -> None:
+    projections = pd.read_csv(Path("tests/fixtures/mini_slate.csv"))
+    if drop:
+        projections = projections.drop(columns=["ownership"])
+    else:
+        projections["ownership"] = 0.0
+    eng = SamplerEngine(projections, seed=9, out_dir=tmp_path)
+    meta = eng.generate(1)
+    rows = _read_base(tmp_path / "field_base.jsonl")
+    assert meta["field_base_count"] == 1
+    assert len(rows) == 1
+
+
 @settings(max_examples=5, suppress_health_check=[HealthCheck.function_scoped_fixture])  # type: ignore[misc]
 @given(st.integers(min_value=12, max_value=18))  # type: ignore[misc]
 def test_property_valid_lineups(tmp_path: Path, n_players: int) -> None:


### PR DESCRIPTION
## Summary
- fall back to uniform sampling when ownership data is missing or zero
- test lineup generation without ownership inputs

## Testing
- `uv sync --dev`
- `uv run ruff check field_sampler/engine.py tools/sample_field.py tests/test_field_sampler_engine.py validators/lineup_rules.py`
- `uv run black --check field_sampler/engine.py tools/sample_field.py tests/test_field_sampler_engine.py validators/lineup_rules.py`
- `uv run mypy field_sampler/engine.py tools/sample_field.py tests/test_field_sampler_engine.py validators/lineup_rules.py`
- `uv run pytest tests/test_field_sampler_engine.py -q` *(skipped: hypothesis not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68bf9c4298c4832cb05663ab247ebff8