### PR TITLE
fix: guard position types and eligibility

### DIFF
--- a/field_sampler/engine.py
+++ b/field_sampler/engine.py
@@ -22,7 +22,7 @@ class PositionAllocator:
     def eligible(self, slot: str, taken: set[str]) -> pd.DataFrame:
         mask = ~self.pool["player_id"].isin(taken)
         subset = self.pool[mask]
-        allowed = DK_POSITION_ELIGIBILITY.get(slot, set())
+        allowed = set(DK_POSITION_ELIGIBILITY.get(slot, []))
         elig_mask = subset["positions"].apply(
             lambda s: bool(allowed & set(str(s).split("/")))
         )

--- a/processes/optimizer/adapter.py
+++ b/processes/optimizer/adapter.py
@@ -274,11 +274,17 @@ def _build_player_pool(projections_df: pd.DataFrame) -> dict[str, dict[str, Any]
             continue
         
         # Parse positions - handle both string and list formats
-        positions_raw = row.get("pos", "")
+        positions_raw = row.get("pos")
         if isinstance(positions_raw, str):
-            positions = [p.strip() for p in positions_raw.replace("/", ",").split(",") if p.strip()]
+            positions = [
+                p.strip()
+                for p in positions_raw.replace("/", ",").split(",")
+                if p.strip()
+            ]
+        elif isinstance(positions_raw, Sequence):
+            positions = [str(p).strip() for p in positions_raw if str(p).strip()]
         else:
-            positions = list(positions_raw) if positions_raw else []
+            positions = []
         
         if not positions:
             positions = ["UTIL"]


### PR DESCRIPTION
## Summary
- convert DraftKings slot eligibility lists to sets before intersection
- handle NaN `pos` values when building optimizer player pool

## Testing
- ⚠️ `uv sync`
- ⚠️ `uv run ruff check .`
- ⚠️ `uv run black --check .`
- ⚠️ `uv run mypy .`
- ⚠️ `uv run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c04bad3d68832c82d49abb0e318e0f