### PR TITLE
PRP-RUNS-02: run registry helpers and docs

### DIFF
--- a/docs/runs/README.md
+++ b/docs/runs/README.md
@@ -1,0 +1,18 @@
+# Run Registry
+
+Run outputs are persisted under the `runs/` directory using the structure:
+
+```
+runs/<SLATE_KEY>/<module>/<RUN_ID>/
+  run_meta.json
+  inputs_hash.json      # optional
+  validation_metrics.json  # optional
+  artifacts/
+```
+
+`run_meta.json` stores core metadata such as the module name, slate key, run id and
+creation timestamp. Optional `inputs_hash.json` and `validation_metrics.json`
+capture hashes of input files and validation statistics respectively.
+
+Helpers in `src/runs/api.py` provide functions to save runs, list available runs
+and prune old entries.

--- a/src/runs/__init__.py
+++ b/src/runs/__init__.py
@@ -1,3 +1,14 @@
+"""Public API for run registry helpers."""
+
+from .api import (
+    gen_run_id,
+    gen_slate_key,
+    get_run,
+    list_runs,
+    prune_runs,
+    save_run,
+)
+
 __all__ = [
     "save_run",
     "get_run",
@@ -6,4 +17,3 @@ __all__ = [
     "gen_slate_key",
     "gen_run_id",
 ]
-

--- a/tests/test_run_registry.py
+++ b/tests/test_run_registry.py
@@ -1,0 +1,34 @@
+import json
+from pathlib import Path
+
+from _pytest.monkeypatch import MonkeyPatch
+
+from src.runs import get_run, list_runs, save_run
+
+
+def test_save_and_list_runs(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    monkeypatch.setenv("PROJECT_ROOT", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+    meta = {"foo": "bar"}
+    inputs_hash = {"hash": "abc"}
+    validation_metrics = {"rows": 10}
+
+    result = save_run(
+        slate_key="slate",
+        module="mod",
+        meta=meta,
+        inputs_hash=inputs_hash,
+        validation_metrics=validation_metrics,
+    )
+
+    run_dir = Path(tmp_path) / "runs" / "slate" / "mod" / result.run_id
+    assert json.loads((run_dir / "run_meta.json").read_text())["foo"] == "bar"
+    assert json.loads((run_dir / "inputs_hash.json").read_text()) == inputs_hash
+    val_metrics = json.loads((run_dir / "validation_metrics.json").read_text())
+    assert val_metrics == validation_metrics
+
+    runs = list_runs("slate", "mod")
+    assert runs and runs[0]["run_id"] == result.run_id
+
+    loaded = get_run("slate", "mod", result.run_id)
+    assert loaded["foo"] == "bar"


### PR DESCRIPTION
## Summary
- expose run registry helpers via `src.runs`
- allow `save_run` to persist `inputs_hash.json` and `validation_metrics.json`
- document run registry layout and add regression test

## Testing
- `uv sync`
- `ruff check src/runs/__init__.py src/runs/api.py tests/test_run_registry.py`
- `black --check src/runs/__init__.py src/runs/api.py tests/test_run_registry.py`
- `uv run mypy src/runs/api.py src/runs/__init__.py tests/test_run_registry.py`
- `pytest tests/test_run_registry.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0585752ac832cace47e4c0c40e135