### PR TITLE
test: update sampler engine tests

### DIFF
--- a/tests/test_field_sampler_engine.py
+++ b/tests/test_field_sampler_engine.py
@@ -5,7 +5,7 @@ from typing import Any, cast
 import pandas as pd
 import pytest
 
-from processes.field_sampler.engine import SamplerEngine
+from field_sampler.engine import SamplerEngine
 from validators.lineup_rules import DK_SLOTS_ORDER, LineupValidator
 
 hypothesis = pytest.importorskip("hypothesis")
@@ -21,18 +21,18 @@ def _read_base(path: Path) -> list[dict[str, Any]]:
 
 def test_golden_mini_slate(tmp_path: Path) -> None:
     projections = pd.read_csv(Path("tests/fixtures/mini_slate.csv"))
-    eng = SamplerEngine(projections, seed=1, out_dir=tmp_path, compat_mode=True)
+    eng = SamplerEngine(projections, seed=1, out_dir=tmp_path)
     eng.generate(1)
     rows = _read_base(tmp_path / "field_base.jsonl")
     assert rows[0]["players"] == [
         "p1",
-        "p2",
-        "p3",
-        "p12",
-        "p13",
-        "p6",
+        "p10",
+        "p7",
         "p4",
-        "p5",
+        "p8",
+        "p6",
+        "p11",
+        "p12",
     ]
     validator = LineupValidator()
     lineup = list(
@@ -47,7 +47,7 @@ def test_golden_mini_slate(tmp_path: Path) -> None:
 
 def test_salary_and_team_limits(tmp_path: Path) -> None:
     projections = pd.read_csv(Path("tests/fixtures/mini_slate.csv"))
-    eng = SamplerEngine(projections, seed=2, out_dir=tmp_path, compat_mode=True)
+    eng = SamplerEngine(projections, seed=2, out_dir=tmp_path)
     eng.generate(3)
     rows = _read_base(tmp_path / "field_base.jsonl")
     validator = LineupValidator()
@@ -68,7 +68,7 @@ def test_salary_violation_rejected(tmp_path: Path) -> None:
         [{"player_id": "bad", "team": "Z", "positions": "PG", "salary": 60000}]
     )
     projections = pd.concat([projections, extra], ignore_index=True)
-    eng = SamplerEngine(projections, seed=3, out_dir=tmp_path, compat_mode=True)
+    eng = SamplerEngine(projections, seed=3, out_dir=tmp_path)
     eng.generate(2)
     rows = _read_base(tmp_path / "field_base.jsonl")
     for row in rows:
@@ -82,14 +82,18 @@ def test_uniform_weights_without_ownership(tmp_path: Path, drop: bool) -> None:
         projections = projections.drop(columns=["ownership"])
     else:
         projections["ownership"] = 0.0
-    eng = SamplerEngine(projections, seed=9, out_dir=tmp_path, compat_mode=True)
+    eng = SamplerEngine(projections, seed=9, out_dir=tmp_path)
     meta = eng.generate(1)
     rows = _read_base(tmp_path / "field_base.jsonl")
     assert meta["field_base_count"] == 1
     assert len(rows) == 1
 
 
-@settings(max_examples=2, suppress_health_check=[HealthCheck.function_scoped_fixture])  # type: ignore[misc]
+@settings(
+    max_examples=2,
+    deadline=None,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)  # type: ignore[misc]
 @given(st.integers(min_value=12, max_value=18))  # type: ignore[misc]
 def test_property_valid_lineups(tmp_path: Path, n_players: int) -> None:
     ids = [f"p{i}" for i in range(n_players)]
@@ -109,7 +113,7 @@ def test_property_valid_lineups(tmp_path: Path, n_players: int) -> None:
             }
         )
     projections = pd.DataFrame(rows)
-    eng = SamplerEngine(projections, seed=0, out_dir=tmp_path, compat_mode=True)
+    eng = SamplerEngine(projections, seed=0, out_dir=tmp_path)
     meta = eng.generate(5)
     rows = _read_base(tmp_path / "field_base.jsonl")
     validator = LineupValidator()
@@ -128,13 +132,13 @@ def test_property_valid_lineups(tmp_path: Path, n_players: int) -> None:
     assert valid / meta["attempts"] >= 0.01
 
 
-# Tests for improved sampler (compat_mode=False)
+# Tests for sampler engine
 
 
 def test_improved_sampler_basic(tmp_path: Path) -> None:
     """Test improved sampler generates valid lineups."""
     projections = pd.read_csv(Path("tests/fixtures/mini_slate.csv"))
-    eng = SamplerEngine(projections, seed=42, out_dir=tmp_path, compat_mode=False)
+    eng = SamplerEngine(projections, seed=42, out_dir=tmp_path)
     eng.generate(3)
     rows = _read_base(tmp_path / "field_base.jsonl")
 
@@ -156,15 +160,11 @@ def test_improved_sampler_efficiency(tmp_path: Path) -> None:
     projections = pd.read_csv(Path("tests/fixtures/mini_slate.csv"))
 
     # Test improved sampler
-    eng_improved = SamplerEngine(
-        projections, seed=123, out_dir=tmp_path / "improved", compat_mode=False
-    )
+    eng_improved = SamplerEngine(projections, seed=123, out_dir=tmp_path / "improved")
     meta_improved = eng_improved.generate(5)
 
     # Test legacy sampler
-    eng_legacy = SamplerEngine(
-        projections, seed=123, out_dir=tmp_path / "legacy", compat_mode=True
-    )
+    eng_legacy = SamplerEngine(projections, seed=123, out_dir=tmp_path / "legacy")
     meta_legacy = eng_legacy.generate(5)
 
     # Both should generate same number of lineups
@@ -178,7 +178,11 @@ def test_improved_sampler_efficiency(tmp_path: Path) -> None:
     assert meta_legacy["attempts"] > 0
 
 
-@settings(max_examples=2, suppress_health_check=[HealthCheck.function_scoped_fixture])  # type: ignore[misc]
+@settings(
+    max_examples=2,
+    deadline=None,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)  # type: ignore[misc]
 @given(st.integers(min_value=10, max_value=15))  # type: ignore[misc]
 def test_improved_sampler_property_based(tmp_path: Path, n_players: int) -> None:
     """Property-based test for improved sampler with various player pools."""
@@ -201,7 +205,7 @@ def test_improved_sampler_property_based(tmp_path: Path, n_players: int) -> None
         )
 
     projections = pd.DataFrame(rows)
-    eng = SamplerEngine(projections, seed=42, out_dir=tmp_path, compat_mode=False)
+    eng = SamplerEngine(projections, seed=42, out_dir=tmp_path)
     meta = eng.generate(3)
 
     rows_generated = _read_base(tmp_path / "field_base.jsonl")
@@ -223,39 +227,3 @@ def test_improved_sampler_property_based(tmp_path: Path, n_players: int) -> None
     assert valid_count == len(rows_generated)
     assert len(rows_generated) <= 3  # Should generate requested amount or fewer
     assert meta["attempts"] > 0
-
-
-def test_sampler_modes_produce_different_results(tmp_path: Path) -> None:
-    """Test that compat_mode and improved mode produce different results but both
-    valid."""
-    projections = pd.read_csv(Path("tests/fixtures/mini_slate.csv"))
-
-    # Generate with both modes using same seed
-    eng_legacy = SamplerEngine(
-        projections, seed=999, out_dir=tmp_path / "legacy", compat_mode=True
-    )
-    eng_improved = SamplerEngine(
-        projections, seed=999, out_dir=tmp_path / "improved", compat_mode=False
-    )
-
-    eng_legacy.generate(1)
-    eng_improved.generate(1)
-
-    legacy_rows = _read_base(tmp_path / "legacy" / "field_base.jsonl")
-    improved_rows = _read_base(tmp_path / "improved" / "field_base.jsonl")
-
-    # Both should generate exactly one lineup
-    assert len(legacy_rows) == 1
-    assert len(improved_rows) == 1
-
-    # Lineups will likely be different (different algorithms)
-    legacy_players = legacy_rows[0]["players"]
-    improved_players = improved_rows[0]["players"]
-
-    # Both should be valid
-    validator = LineupValidator()
-    legacy_lineup = list(zip(DK_SLOTS_ORDER, legacy_players, strict=False))
-    improved_lineup = list(zip(DK_SLOTS_ORDER, improved_players, strict=False))
-
-    assert validator.validate(legacy_lineup, projections)
-    assert validator.validate(improved_lineup, projections)


### PR DESCRIPTION
## Summary
- fix SamplerEngine import and remove legacy compat flag
- update golden mini slate lineup for new sampler output
- relax Hypothesis deadlines in property-based tests

## Testing
- `uv run ruff check tests/test_field_sampler_engine.py`
- `uv run black --check tests/test_field_sampler_engine.py`
- `uv run mypy tests/test_field_sampler_engine.py`
- `uv run pytest tests/test_field_sampler_engine.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0645dd14c832cabb00210bf027393