### PR TITLE
feat: unify field sampler engine

### DIFF
--- a/docs/USAGE-field-sampler.md
+++ b/docs/USAGE-field-sampler.md
@@ -14,6 +14,7 @@ Required knobs:
 * `slate_id` – slate identifier
 * `salary_cap` – contest salary cap (default 50000)
 * `max_per_team` – max players per team (default 4)
+* `variant_catalog` – optional DataFrame of pre-built lineups to inject
 
 ## Running from Python
 
@@ -24,6 +25,14 @@ from field_sampler.engine import SamplerEngine
 projections = pd.read_csv("projections.csv")
 engine = SamplerEngine(projections, seed=42, slate_id="20250101_NBA")
 engine.generate(100)
+```
+
+To inject pre-built variants:
+
+```python
+variant_catalog = pd.read_parquet("variant_catalog.parquet")
+engine = SamplerEngine(projections, seed=42, slate_id="20250101_NBA")
+engine.generate(100, variant_catalog=variant_catalog)
 ```
 
 ## CLI
@@ -49,5 +58,6 @@ python -m tools.sample_field \
 Artifacts are written under `./artifacts/`:
 
 * `field_base.jsonl` – sampled public field
+* `field_merged.jsonl` – field with injected lineups (if any)
 * `metrics.json` – run metadata
 * `audit_fs.md` – summary report

--- a/processes/field_sampler/_legacy/field_sampler.py
+++ b/processes/field_sampler/_legacy/field_sampler.py
@@ -14,6 +14,14 @@ import numpy as np
 import yaml
 from src.config import paths
 
+import warnings
+
+warnings.warn(
+    "processes.field_sampler._legacy.field_sampler is deprecated; use field_sampler.engine",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
 ALLOWED_SLOTS = {"PG", "SG", "SF", "PF", "C", "G", "F", "UTIL"}
 
 

--- a/processes/field_sampler/injection_model.py
+++ b/processes/field_sampler/injection_model.py
@@ -11,6 +11,14 @@ import pandas as pd
 
 from validators.lineup_rules import DK_SLOTS_ORDER, LineupValidator
 
+import warnings
+
+warnings.warn(
+    "processes.field_sampler.injection_model is deprecated; use field_sampler.engine",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
 
 def _utc_now() -> str:
     now = datetime.now(timezone.utc)

--- a/tests/test_field_adapter_default_engine.py
+++ b/tests/test_field_adapter_default_engine.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+
+import pandas as pd
+
+from processes.field_sampler import adapter as field
+
+
+def test_adapter_defaults_to_engine(tmp_path: Path) -> None:
+    proj_csv = Path("tests/fixtures/mini_slate.csv")
+    vc = pd.DataFrame(columns=["players"])  # empty variant catalog
+    vc_path = tmp_path / "variant_catalog.parquet"
+    vc.to_parquet(vc_path)
+    out_root = tmp_path / "out"
+    out_root.mkdir(parents=True, exist_ok=True)
+
+    result = field.run_adapter(
+        slate_id="SLATE",
+        config_path=None,
+        config_kv=["field_size=1", f"projections_csv={proj_csv}"],
+        seed=1,
+        out_root=out_root,
+        input_path=vc_path,
+    )
+
+    field_path = Path(result["field_path"])
+    assert field_path.exists()

--- a/tests/test_field_sampler_injection.py
+++ b/tests/test_field_sampler_injection.py
@@ -2,15 +2,12 @@ import json
 from pathlib import Path
 
 import pandas as pd
-import pytest
 
-from processes.field_sampler import injection_model as fs
+from field_sampler.engine import run_sampler
 from validators.lineup_rules import DK_SLOTS_ORDER, LineupValidator
 
 
-def test_build_field_creates_artifacts(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_build_field_creates_artifacts(tmp_path: Path) -> None:
     projections = pd.DataFrame(
         [
             {"player_id": "p1", "team": "A", "positions": "PG", "salary": 10000},
@@ -25,13 +22,15 @@ def test_build_field_creates_artifacts(
     )
     variant_catalog = pd.DataFrame([{"players": [f"p{i}" for i in range(1, 9)]}])
 
-    monkeypatch.chdir(tmp_path)
-    metrics = fs.build_field(
+    metrics = run_sampler(
         projections,
-        field_size=1,
+        {
+            "field_size": 1,
+            "slate_id": "SLATE",
+            "out_dir": tmp_path / "artifacts",
+            "variant_catalog": variant_catalog,
+        },
         seed=1,
-        slate_id="SLATE",
-        variant_catalog=variant_catalog,
     )
 
     base_path = tmp_path / "artifacts" / "field_base.jsonl"


### PR DESCRIPTION
## Summary
- default field sampler adapter to `field_sampler.engine.run_sampler`
- support injecting variant catalogs into sampler engine
- mark legacy field sampler modules as deprecated
- document canonical sampler usage and add default adapter test

## Testing
- `uv sync`
- `ruff check .` *(fails: numerous lint issues in repository)*
- `black --check .` *(fails: would reformat multiple files)*
- `mypy` *(fails: missing pydantic plugin)*
- `pytest -q` *(fails: 42 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c08a7299d4832c92f2898c76004f49