### PR TITLE
PRP-FS-05: Field Sampler Unification (retry)

### DIFF
--- a/docs/PRPs/PRP-FS-05-Field-Sampler-Unification.md
+++ b/docs/PRPs/PRP-FS-05-Field-Sampler-Unification.md
@@ -102,6 +102,14 @@
 
 ---
 
+### 2025 Update
+- Adapter ships with built-in engine (`processes.field_sampler.engine.run_sampler`).
+- Engine returns entrants/telemetry and is deterministic via a `seed` knob.
+- Tests moved under `tests/field_sampler/` covering adapter, engine and injection model.
+- No migration needed; `FIELD_SAMPLER_IMPL` still overrides the default.
+
+---
+
 ## Expected Benefits
 - Single Source of Truth across optimizer → variant builder → sampler → simulator
 - Cleaner adapter UX: users don’t manually select engines

--- a/processes/field_sampler/engine.py
+++ b/processes/field_sampler/engine.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import random
+from typing import Any
+
+import pandas as pd
+
+from validators.lineup_rules import DK_SLOTS_ORDER
+
+
+def run_sampler(
+    catalog_df: pd.DataFrame, knobs: dict[str, Any], seed: int
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Sample field entrants from a variant catalog.
+
+    Parameters
+    ----------
+    catalog_df:
+        DataFrame containing at minimum a ``players`` column of length-8 lists.
+    knobs:
+        Engine configuration produced by :func:`map_config_to_knobs`. Unknown
+        keys are ignored.
+    seed:
+        RNG seed to ensure determinism.
+
+    Returns
+    -------
+    entrants, telemetry
+        ``entrants`` is a list of mappings with ``players`` and optional
+        ``variant_id``/``lineup_id``. ``telemetry`` contains auxiliary metrics.
+    """
+    rng = random.Random(seed)
+    field_size = int(knobs.get("field_size", 0) or len(catalog_df))
+    idxs = list(range(len(catalog_df)))
+    rng.shuffle(idxs)
+
+    entrants: list[dict[str, Any]] = []
+    for idx in idxs[:field_size]:
+        row = catalog_df.iloc[idx]
+        players = list(row.get("players") or [])
+        export_row = row.get("export_csv_row")
+        if not export_row:
+            export_row = ",".join(f"{s} {p}" for s, p in zip(DK_SLOTS_ORDER, players, strict=False))
+        ent: dict[str, Any] = {
+            "origin": "variant",
+            "variant_id": str(row.get("variant_id", "")),
+            "players": players,
+            "export_csv_row": str(export_row),
+            "weight": float(row.get("weight", 1.0)),
+        }
+        lineup_id = row.get("lineup_id")
+        if lineup_id is not None and not pd.isna(lineup_id):
+            ent["lineup_id"] = str(lineup_id)
+        entrants.append(ent)
+
+    telemetry = {"sampled": len(entrants)}
+    return entrants, telemetry

--- a/tests/field_sampler/test_adapter_core.py
+++ b/tests/field_sampler/test_adapter_core.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+import pytest
+
+from processes.field_sampler import adapter as field
+
+
+def _export_row(players: list[str]) -> str:
+    slots = ["PG", "SG", "SF", "PF", "C", "G", "F", "UTIL"]
+    return ",".join(f"{s} {p}" for s, p in zip(slots, players, strict=False))
+
+
+def _stub_sampler(catalog_df: pd.DataFrame, knobs: dict[str, Any], seed: int):
+    entrants = []
+    for _, row in catalog_df.iterrows():
+        players = list(row["players"])
+        entrants.append(
+            {"origin": "variant", "players": players, "export_csv_row": _export_row(players)}
+        )
+    return entrants
+
+
+def test_manifest_registry_and_runid(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    vc = pd.DataFrame([{"players": [f"p{i}" for i in range(8)]}])
+    cat = tmp_path / "vc.parquet"
+    vc.to_parquet(cat)
+    monkeypatch.setattr(field, "_load_sampler", lambda: _stub_sampler)
+
+    class FakeDT:
+        @staticmethod
+        def now(tz=None):
+            return datetime(2025, 11, 1, 0, 0, 0, tzinfo=UTC)
+
+    monkeypatch.setattr(field, "datetime", FakeDT)
+    out = tmp_path / "out"
+    res1 = field.run_adapter(
+        slate_id="S",
+        config_path=None,
+        config_kv=None,
+        seed=1,
+        out_root=out,
+        tag=None,
+        input_path=cat,
+    )
+    res2 = field.run_adapter(
+        slate_id="S",
+        config_path=None,
+        config_kv=None,
+        seed=1,
+        out_root=out,
+        tag=None,
+        input_path=cat,
+    )
+    assert res1["run_id"] == res2["run_id"]
+    reg = pd.read_parquet(Path(res1["registry_path"]))
+    assert (reg["run_id"] == res1["run_id"]).any()
+    run_dir = Path(res1["field_path"]).parent
+    assert (run_dir / "field.parquet").exists()
+    assert (run_dir / "metrics.parquet").exists()
+
+
+def _bad_sampler(catalog_df: pd.DataFrame, knobs: dict[str, Any], seed: int):
+    players = [f"p{i}" for i in range(7)]
+    return [{"origin": "variant", "players": players, "export_csv_row": "PG p0"}]
+
+
+def test_failfast_no_write(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    vc = pd.DataFrame([{"players": [f"p{i}" for i in range(8)]}])
+    cat = tmp_path / "vc.parquet"
+    vc.to_parquet(cat)
+    monkeypatch.setattr(field, "_load_sampler", lambda: _bad_sampler)
+    out = tmp_path / "out"
+    with pytest.raises(ValueError):
+        field.run_adapter(
+            slate_id="S",
+            config_path=None,
+            config_kv=None,
+            seed=1,
+            out_root=out,
+            tag=None,
+            input_path=cat,
+        )
+    assert not (out / "runs" / "field").exists()

--- a/tests/field_sampler/test_dedup_diversity.py
+++ b/tests/field_sampler/test_dedup_diversity.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from processes.field_sampler import adapter as field
+
+
+def _export_row(players: list[str]) -> str:
+    slots = ["PG", "SG", "SF", "PF", "C", "G", "F", "UTIL"]
+    return ",".join(f"{s} {p}" for s, p in zip(slots, players, strict=False))
+
+
+def _stub_diversity(catalog_df: pd.DataFrame, knobs: dict[str, Any], seed: int):
+    base = [f"p{i}" for i in range(8)]
+
+    def mk(players: list[str]) -> dict[str, Any]:
+        return {"origin": "variant", "players": players, "export_csv_row": _export_row(players)}
+
+    unique = knobs.get("de-dup") or (knobs.get("diversity", 0.0) or 0.0) >= 0.5
+    if unique:
+        entrants = []
+        for i in range(4):
+            players = list(base)
+            players[-1] = f"x{i}"
+            entrants.append(mk(players))
+    else:
+        entrants = [mk(base) for _ in range(4)]
+    return entrants
+
+
+def test_dedup_and_diversity_metric(tmp_path: Path, monkeypatch) -> None:
+    cat_path = tmp_path / "vc.parquet"
+    pd.DataFrame([{"players": [f"p{i}" for i in range(8)]}]).to_parquet(cat_path)
+    monkeypatch.setattr(field, "_load_sampler", lambda: _stub_diversity)
+    out = tmp_path / "out"
+    low = field.run_adapter(
+        slate_id="S",
+        config_path=None,
+        config_kv=["diversity=0"],
+        seed=1,
+        out_root=out,
+        tag=None,
+        input_path=cat_path,
+    )
+    high = field.run_adapter(
+        slate_id="S",
+        config_path=None,
+        config_kv=["diversity=1"],
+        seed=1,
+        out_root=out,
+        tag=None,
+        input_path=cat_path,
+    )
+    low_risk = float(
+        pd.read_parquet(Path(low["metrics_path"])).iloc[0].get("duplication_risk", 0.0)
+    )
+    high_risk = float(
+        pd.read_parquet(Path(high["metrics_path"])).iloc[0].get("duplication_risk", 0.0)
+    )
+    assert high_risk < low_risk

--- a/tests/field_sampler/test_engine_injection.py
+++ b/tests/field_sampler/test_engine_injection.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+
+from processes.field_sampler import engine
+from processes.field_sampler import injection_model as fs
+
+
+def test_engine_smoke() -> None:
+    catalog = pd.DataFrame([{"players": [f"p{i}" for i in range(8)]}])
+    entrants1, _ = engine.run_sampler(catalog, {"field_size": 1}, seed=1)
+    entrants2, _ = engine.run_sampler(catalog, {"field_size": 1}, seed=1)
+    assert entrants1 == entrants2
+    assert entrants1[0]["players"] == [f"p{i}" for i in range(8)]
+
+
+def test_injection_model(tmp_path: Path, monkeypatch) -> None:
+    projections = pd.DataFrame(
+        [
+            {"player_id": f"p{i}", "team": "A", "positions": "PG", "salary": 1000 * i}
+            for i in range(1, 9)
+        ]
+    )
+    vc = pd.DataFrame([{"players": [f"p{i}" for i in range(1, 9)]}])
+    monkeypatch.chdir(tmp_path)
+    metrics = fs.build_field(projections, field_size=1, seed=1, slate_id="SL", variant_catalog=vc)
+    base = tmp_path / "artifacts" / "field_base.jsonl"
+    merged = tmp_path / "artifacts" / "field_merged.jsonl"
+    assert base.exists() and merged.exists()
+    merged_rows = [json.loads(line) for line in merged.read_text().splitlines()]
+    assert metrics["field_base_count"] == 1
+    assert metrics["field_merged_count"] == 2
+    assert merged_rows[1]["source"] == "injected"


### PR DESCRIPTION
## Summary
- wire `processes.field_sampler.engine.run_sampler` as default sampler
- add lightweight sampler engine returning entrants/telemetry
- add focused field sampler tests and PRP update

## Allowed Paths
- `processes/field_sampler/**`
- `validators/**`
- `tests/field_sampler/**`
- `docs/PRPs/PRP-FS-05-*.md`

## Risk
- Low: isolated to field sampler code and tests

## Validation
- `uv sync --extra dev`
- `ruff check .`
- `black --check .`
- `mypy processes/field_sampler/adapter.py processes/field_sampler/engine.py processes/field_sampler/injection_model.py`
- `pytest tests/field_sampler -q`


------
https://chatgpt.com/codex/tasks/task_e_68c09b08a01c832cb55a5f25416ae614