### PR TITLE
PRP-SIM-01: handle unique lineups in duplication bins

### DIFF
--- a/tests/sim/test_invariants.py
+++ b/tests/sim/test_invariants.py
@@ -1,13 +1,17 @@
 import pandas as pd
+
 from processes.orchestrator.core import _compute_sim_metrics
 
 
 def test_invariants():
-    df = pd.DataFrame([
-        {"prize": 2.0, "finish": 1, "dup_count": 1},
-        {"prize": 0.0, "finish": 2, "dup_count": 1},
-    ])
+    df = pd.DataFrame(
+        [
+            {"prize": 2.0, "finish": 1, "dup_count": 1},
+            {"prize": 0.0, "finish": 2, "dup_count": 1},
+        ]
+    )
     metrics = _compute_sim_metrics(df)
     assert abs(metrics["roi"]["mean"]) < 1e-6
     dup = metrics["duplication"]
     assert dup["unique_fraction"] + dup["dup_fraction"] <= 1.0 + 1e-6
+    assert dup["dup_bins"] == []


### PR DESCRIPTION
## Summary
- avoid mismatch errors when computing duplication bins by grouping with filtered counts and skipping aggregation when no duplicates
- assert empty dup_bins for unique lineups in invariants test

## Testing
- `ruff check processes/orchestrator/core.py tests/sim/test_invariants.py`
- `pytest tests/sim/test_invariants.py -vv` *(skipped: Temporarily skipped during stabilization (FS-07))*
- `pytest tests/orchestrator/test_metrics_contract.py::test_metrics_computation_invariants -vv` *(skipped: Temporarily skipped during stabilization (FS-07))*

------
https://chatgpt.com/codex/tasks/task_e_68c0e4ced078832cbf95770c7498d85a